### PR TITLE
Support this.addWatchFile in rollup.js v1.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,23 +19,27 @@ export default function elm (options = {}) {
       if (!/.elm$/i.test(id)) return null
       if (!filter(id)) return null
 
-      return transform(source, id, opt)
-      .catch(err => this.error(err))
+      const transform = async (source, id, options) => {
+        const elm = await compile(id, options.compiler)
+        const dependencies = await elmCompiler.findAllDependencies(id)
+        const compiled = {
+          code: wrapElmCode(elm),
+          map: { mappings: '' }
+        }
+
+        if (this.addWatchFile) {
+          dependencies.forEach(this.addWatchFile)
+        } else {
+          compiled.dependencies = dependencies
+        }
+
+        return compiled
+      }
+
+      return transform(source, id, opt).catch(err => this.error(err))
     }
   }
 }
-
-async function transform (source, id, options) {
-  const elm = await compile(id, options.compiler)
-  const dependencies = await elmCompiler.findAllDependencies(id)
-
-  return {
-    code: wrapElmCode(elm),
-    map: { mappings: '' },
-    dependencies
-  }
-}
-
 
 async function compile (filename, options) {
   const compilerOptions = {


### PR DESCRIPTION
Thanks for publishing such the nice plugin ✨ This plugin helped some my Elm projects.

## What this PR does

In compilation with rollup.js 1.x, we will see this warning:

> (!) Returning "dependencies" from the "transform" hook as done by plugin elm is deprecated. The "this.addWatchFile" plugin context function should be used instead.

This PR provides supporting `this.addWatchFile` instead of returning `.dependencies` on the result of `transform`

To catch the context of transform; `this` on `transform()`, moved its scope.